### PR TITLE
[WIP] Add vectorizable version of `compute_eloss`

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/egsnrc/egs_home/tutor4/make_egsfortran.py
+++ b/egsnrc/egs_home/tutor4/make_egsfortran.py
@@ -65,7 +65,7 @@ with working_dir(HERE):
         # Likely will be fixed in patch numpy release, or at least will
         # work if create one Fortran function called from many
         # (see also https://github.com/numpy/numpy/issues/18341)
-        f"python3.9 -m numpy.f2py {F2PY_OPTIONS} -c {LIB_NAME}.pyf {USER_CODE_FORTRAN}".split(),
+        f"python3.8 -m numpy.f2py {F2PY_OPTIONS} -c {LIB_NAME}.pyf {USER_CODE_FORTRAN}".split(),
         # capture_output=True, encoding="utf8"
     )
     if proc.returncode != 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy
+jaxlib
 jax

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy
+jax


### PR DESCRIPTION
* as experiment in jax use on near-pure math function
* confirmed correct on previous test inputs/outputs collected into arrays (>~500 function calls equiv).